### PR TITLE
Fix(frontend): Add missing tsconfig.json to resolve module not found …

### DIFF
--- a/frontend/roam-frontend/tsconfig.json
+++ b/frontend/roam-frontend/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "src"
+  ]
+}


### PR DESCRIPTION
…error

The frontend application was failing to compile because of a `Module not found: Error: Can't resolve './App'` error. This was due to a missing `tsconfig.json` file in the `frontend/roam-frontend/` directory.

This commit adds a standard `tsconfig.json` for Create React App projects using TypeScript. This file provides the necessary compiler options for TypeScript to correctly resolve modules, including the `./App` import in `index.tsx`.